### PR TITLE
kubectl run is deprecated and is being removed

### DIFF
--- a/docs/guides/certificate/http/overview.md
+++ b/docs/guides/certificate/http/overview.md
@@ -24,7 +24,7 @@ Install Voyager operator in your cluster following the steps [here](/docs/setup/
 2. We are going to use a nginx server as the backend. To deploy nginx server, run the following commands:
 
     ```console
-    kubectl run nginx --image=nginx
+    kubectl create deployment nginx --image=nginx
     kubectl expose deployment nginx --name=web --port=80 --target-port=80
     ```
 


### PR DESCRIPTION
I updated the command to kubectl create deployment, This has no implications on the simple use of kubectl run in the example here from what I can tell.

Summary of the run deprecation on Alex Ellis [blog](https://medium.com/@alexellisuk/kubernetes-1-18-broke-kubectl-run-heres-what-to-do-about-it-2a88e5fb389a).

Signed-off-by: Josh Cox <josh@webhosting.coop>